### PR TITLE
Add Toaster module to module list so build system knows to include it

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -9,7 +9,8 @@ define([
            'dijit/MenuItem',
            'JBrowse/Plugin',
            './View/FileDialog',
-           './View/CMapFileDialog'
+           './View/CMapFileDialog',
+           'dojox/widget/Toaster'
        ],
        function(
            declare,
@@ -41,7 +42,7 @@ return declare( JBrowsePlugin,
         }, this);
         // this.browser.afterMilestone('initView',function() {
         //   this.browser.addGlobalMenuItem('file',new dijitMenuItem(
-            
+
         //     {
         //       label : 'Add BioNanoGenomics CMap file',
         //       iconClass : 'bionanoUploadIcon',


### PR DESCRIPTION
The File dialog references dojox/widget/Toaster but if the JBrowse code is minified then this module can be forced to be included by referencing it in main.js

